### PR TITLE
Fix ignoreDifferences

### DIFF
--- a/apps/linkerd/linkerd-control-plane.yaml
+++ b/apps/linkerd/linkerd-control-plane.yaml
@@ -23,6 +23,21 @@ spec:
   syncPolicy:
     automated: {}
   ignoreDifferences:
+  - group: batch
+    jsonPointers:
+      - /spec/schedule
+    kind: CronJob
+    name: linkerd-heartbeat
+  - group: apps
+    jsonPointers:
+      - /spec/template/metadata/annotations/checksum~1config
+    kind: Deployment
+    name: linkerd-destination
+  - group: apps
+    jsonPointers:
+      - /spec/template/metadata/annotations/checksum~1config
+    kind: Deployment
+    name: linkerd-proxy-injector
   - group: ""
     kind: Secret
     name:  linkerd-proxy-injector-k8s-tls
@@ -41,17 +56,17 @@ spec:
     jsonPointers:
     - /data/tls.crt
     - /data/tls.key
-  - group: admissionregistration.k8s.io/v1
+  - group: admissionregistration.k8s.io
     kind: MutatingWebhookConfiguration
     name:  linkerd-proxy-injector-webhook-config
     jsonPointers:
     - /webhooks/0/clientConfig/caBundle
-  - group: admissionregistration.k8s.io/v1
+  - group: admissionregistration.k8s.io
     kind: ValidatingWebhookConfiguration
     name:  linkerd-sp-validator-webhook-config
     jsonPointers:
     - /webhooks/0/clientConfig/caBundle
-  - group: admissionregistration.k8s.io/v1
+  - group: admissionregistration.k8s.io
     kind: ValidatingWebhookConfiguration
     name:  linkerd-policy-validator-webhook-config
     jsonPointers:


### PR DESCRIPTION
This PR fixes ignoreDifferences otherwise argocd will be out of sync every few minutes and restart continously restart `linkerd-destination` and `linkerd-proxy-injector` pods


1. Fix the `group` field for the `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` entries by removing the API version as per argocd requirements [here](https://argo-cd.readthedocs.io/en/stable/user-guide/diffing/#application-level-configuration)

<img width="793" alt="image" src="https://github.com/BuoyantIO/real-world-argo-linkerd/assets/22263806/6bf442d2-87b2-4bdb-ad8d-0e3f63074274">

2. Adds 3 additional entries. 1 to ignore the CronJob `schedule` and 2 entries to ignore the `checksum/config` annotation in the `linkerd-destination` and `linkerd-proxy-injector` Deployments (See https://github.com/linkerd/linkerd2/pull/11440)
